### PR TITLE
Low FPS Changes

### DIFF
--- a/src/pages/docs/low-fps.md
+++ b/src/pages/docs/low-fps.md
@@ -34,7 +34,7 @@ If you are encountering Low FPS you can try these steps to increase it.
 
 1. [Open the console](/docs/opening-console/)
 
-2. Type `com_maxfps 0` and press Enter (this command unlocks your frame rate)
+2. Type `com_maxfps 250` and press Enter (This command locks your framerate to 250, as higher values are known to cause instability.)
 
 ## Method 4
 

--- a/src/pages/docs/low-fps.md
+++ b/src/pages/docs/low-fps.md
@@ -32,12 +32,12 @@ If you are encountering Low FPS you can try these steps to increase it.
 
 ## Method 3
 
-1. Open the console https://plutonium.pw/docs/opening-console/
+1. [Open the console](/docs/opening-console/)
 
-2. Type /com_maxfps 0 and press Enter (this command will tell the game to have an unlimited FPS cap so once you get this fixed you should set it your monitor refresh rate instead e.g /com_maxfps 60)
+2. Type `com_maxfps 0` and press Enter (this command unlocks your frame rate)
 
 ## Method 4
 
-Some computers can't handle higher graphics, lowering the graphics may help in the in-game graphic options could help on weaker computers.
+Some computers can't handle higher graphics, lowering your graphics settings in game may help on weaker computers.
 
-Also some games may get lower FPS when playing in windowed borderless mode or when playing in fullscreen. Try switching between both modes to see if one gives you more FPS.
+You can also try switching between windowed borderless mode, fullscreen, and normal windowed mode. Try switching between them to see if one gives you more FPS.

--- a/src/pages/docs/low-fps.md
+++ b/src/pages/docs/low-fps.md
@@ -29,3 +29,15 @@ If you are encountering Low FPS you can try these steps to increase it.
 4\. Select your high performance/dedicated gpu and hit save
 
 ![img](https://i.imgur.com/OWfru0K.png)
+
+## Method 3
+
+1. Open the console https://plutonium.pw/docs/opening-console/
+
+2. Type /com_maxfps 0 and press Enter (this command will tell the game to have an unlimited FPS cap so once you get this fixed you should set it your monitor refresh rate instead e.g /com_maxfps 60)
+
+## Method 4
+
+Some computers can't handle higher graphics, lowering the graphics may help in the in-game graphic options could help on weaker computers.
+
+Also some games may get lower FPS when playing in windowed borderless mode or when playing in fullscreen. Try switching between both modes to see if one gives you more FPS.


### PR DESCRIPTION
Method 3 tells the user to uncap the FPS. Even if T6 has unlimited FPS cap by default and IW5 has a high FPS cap by default T4's default FPS cap is 85 which can make the game feel laggy on 144hz monitor. Also some people tend to change this command without knowing/remembering it so it's always nice to have this here.

Method 4 tells the user to lower his graphical settings if his PC can't handle the graphics. Even if it sounds logical some users have no idea how well their PC can run the game and will never go check the graphical settings. Also telling user to try switching between windowed/fullscreen since it can cause low fps issues on some games/computers, especially on crappy laptops.