### PR TITLE
Change of incorrect urls on "Getting Involved" page

### DIFF
--- a/src/pages/docs/getting-involved.md
+++ b/src/pages/docs/getting-involved.md
@@ -6,5 +6,5 @@ is highly encouraged. The community always needs a helping hand, so checking our
 
 ## I want to help but I'm still not sure how
 
-No problem! If you want to make a mod, take a look at our [modding documentation](/modding) or on the [forums](https://forum.plutonium.pw/).
-Think about things that you may have had trouble with when you started, and document the process and share it on the forums. Again, anything that can help Plutonium and our community. If you're still unsure about your technical skills, you can always help us by [contributing](how-can-i-contribute)!
+No problem! If you want to make a mod, take a look at our [modding documentation](/docs/modding) or on the [forums](https://forum.plutonium.pw/).
+Think about things that you may have had trouble with when you started, and document the process and share it on the forums. Again, anything that can help Plutonium and our community. If you're still unsure about your technical skills, you can always help us by [contributing](/docs/how-can-i-contribute)!


### PR DESCRIPTION
There was a wrong url to the modding documentation on the "Getting Involved" page on the plutonium.pw website. This would lead to a 404 Error.
The url was: https://plutonium.pw/modding/
Changed to: https://plutonium.pw/docs/modding/
There was a wrong url to the "Contribution" page on the plutonium.pw website. The would lead to yet another 404 Error.
The url was: https://plutonium.pw/how-can-i-contribute/
Changed to: https://plutonium.pw/docs/how-can-i-contribute/