### PR TITLE
Links On "Getting Involved" Page

### DIFF
--- a/src/pages/docs/getting-involved.md
+++ b/src/pages/docs/getting-involved.md
@@ -6,5 +6,5 @@ is highly encouraged. The community always needs a helping hand, so checking our
 
 ## I want to help but I'm still not sure how
 
-No problem! If you want to make a mod, take a look at our [modding documentation](/docs/modding) or on the [forums](https://forum.plutonium.pw/).
-Think about things that you may have had trouble with when you started, and document the process and share it on the forums. Again, anything that can help Plutonium and our community. If you're still unsure about your technical skills, you can always help us by [contributing](/docs/how-can-i-contribute)!
+No problem! If you want to make a mod, take a look at our [modding documentation](https://plutonium.pw/docs/modding/) or on the [forums](https://forum.plutonium.pw/).
+Think about things that you may have had trouble with when you started, and document the process and share it on the forums. Again, anything that can help Plutonium and our community. If you're still unsure about your technical skills, you can always help us by [contributing](https://plutonium.pw/docs/how-can-i-contribute/)!


### PR DESCRIPTION
Some links on the "Getting Involved" Page are completely wrong. I previously made a pull request (that was accepted 😀) that attempted to fix some of the false redirects, however due to frequent updates in the change of links to wrong pages, I have decided to make another pull request that changes the Modding Documentation and Contributing hyperlinks.
They previously were:
https://plutonium.pw/modding/ --> Which leads to a 404 page when trying to access the Modding section.
https://plutonium.pw/docs/getting-involved/how-can-i-contribute/ --> Which is a weirdly formatted url that leads to another 404 page when trying to access the How Can I Contribute page.
The previous pull request did not end up changing the modding page, for some reason it still redirects to https://plutonium.pw/modding --> which is a page that does not exist.