### PR TITLE
Correct install links

### DIFF
--- a/src/pages/docs/index.mdx
+++ b/src/pages/docs/index.mdx
@@ -20,13 +20,13 @@ This is required regardless of the game you want to play.
 These steps are only required if you do not have the game installed yet from steam/other sources.
 
 <NavTiles>
-    <NavTile title="Installing Black Ops 2" to="/docs/install/#t6" className="bg-yellow-800 ring-orange-300" background={T6background} bgPosition="70% 15%">
+    <NavTile title="Installing Black Ops 2" to="/docs/install/#t6-black-ops-2" className="bg-yellow-800 ring-orange-300" background={T6background} bgPosition="70% 15%">
         Learn how to install Plutonium T6.
     </NavTile>
-    <NavTile title="Installing Modern Warfare 3" to="/docs/install/#iw5" className="bg-green-600 ring-green-300" background={IW5background} bgPosition="50% 10%">
+    <NavTile title="Installing Modern Warfare 3" to="/docs/install/#iw5-modern-warfare-3" className="bg-green-600 ring-green-300" background={IW5background} bgPosition="50% 10%">
         Learn how to install Plutonium IW5.
     </NavTile>
-    <NavTile title="Installing World at War" to="/docs/install/#t4" className="bg-blue-800 ring-blue-400" background={T4background} bgPosition="100% 40%">
+    <NavTile title="Installing World at War" to="/docs/install/#t4-world-at-war" className="bg-blue-800 ring-blue-400" background={T4background} bgPosition="100% 40%">
         Learn how to install Plutonium T4.
     </NavTile>
 </NavTiles>


### PR DESCRIPTION
Commit 62e8675666da40d8d49a70ca0c025a316d8bbd1a updated the install guide to include the full name of the game, not just the engine name. However, the anchor links on the index page were never updated, resulting in users not being automatically sent to the correct section on the install guide.